### PR TITLE
Fix typo of the word 'occurrence'

### DIFF
--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -287,7 +287,7 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 		}
 
 		/**
-		 * Logs the occurence of rewrite rule purging
+		 * Logs the occurrence of rewrite rule purging
 		 */
 		public function log_rewrite_rule_purge() {
 			$this->rewrite_rules_purged = true;


### PR DESCRIPTION
Occurrence is spelled with two `r`s.

While the mispelling happens in several places in the various (mostly premium) plugins, we might as well get them all :-)